### PR TITLE
Fixing Flow for wrapped objects

### DIFF
--- a/lib/Layout/Manager/Flow.pm
+++ b/lib/Layout/Manager/Flow.pm
@@ -179,7 +179,7 @@ override('do_layout', sub {
         }
         $fheight += $l->{height};
         if($l->{width} > $fwidth) {
-            $fwidth += $l->{width};
+            $fwidth = $l->{width};
         }
     }
     $self->used([$fwidth, $fheight]);


### PR DESCRIPTION
I have found a typo that caused the container to always grow to the size of the sum of all lines. Given that the line already has the same width as the sum of its components, finding the largest line should be sufficient.
